### PR TITLE
Item Delete Endpoint

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -40,6 +40,10 @@ class Api::V1::ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    Item.destroy(params[:id])
+  end
+
   private
 
   def valid_merchant_param?

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::ItemsController < ApplicationController
         render json: save_failed, status: :internal_server_error
       end
     else
-      render json: bad_request, status: :bad_request
+      render json: bad_request('Invalid Item Data'), status: :bad_request
     end
   end
 
@@ -41,7 +41,10 @@ class Api::V1::ItemsController < ApplicationController
   end
 
   def destroy
-    Item.destroy(params[:id])
+    destroyer = ItemDestroyer.new(params[:id])
+    destroyer.destroy
+
+    render json: bad_request(destroyer.error), status: :bad_request unless destroyer.error.empty?
   end
 
   private
@@ -94,10 +97,10 @@ class Api::V1::ItemsController < ApplicationController
     [num1, num2].min
   end
 
-  def bad_request
+  def bad_request(status)
     {
       code: 400,
-      status: 'Invalid Item Data'
+      status: status
     }
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,20 +9,4 @@ class Item < ApplicationRecord
 
     Item.all.limit(limit)
   end
-
-  def self.destroy_consider_invoice(id)
-    item = Item.find(id)
-    invoices = item
-                .invoices.includes(:invoice_items)
-
-    require "pry"; binding.pry
-    destroy(id)
-    require "pry"; binding.pry
-
-    invoices.each do |invoice|
-      i = invoice.invoice_items
-      require "pry"; binding.pry
-      Invoice.destroy(invoice.id) if invoice.invoice_items.empty?
-    end
-  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,4 +9,20 @@ class Item < ApplicationRecord
 
     Item.all.limit(limit)
   end
+
+  def self.destroy_consider_invoice(id)
+    item = Item.find(id)
+    invoices = item
+                .invoices.includes(:invoice_items)
+
+    require "pry"; binding.pry
+    destroy(id)
+    require "pry"; binding.pry
+
+    invoices.each do |invoice|
+      i = invoice.invoice_items
+      require "pry"; binding.pry
+      Invoice.destroy(invoice.id) if invoice.invoice_items.empty?
+    end
+  end
 end

--- a/app/services/item_destroyer.rb
+++ b/app/services/item_destroyer.rb
@@ -1,17 +1,36 @@
 class ItemDestroyer
-  def self.destroy_consider_invoice(id)
-    item = Item.find(id)
-    invoices = item.invoices.includes(:invoice_items)
+  attr_reader :item_id, :error
 
-    invoice_ids = item
-    require "pry"; binding.pry
-    destroy(id)
-    require "pry"; binding.pry
+  def initialize(item_id)
+    @item_id = item_id
+    @error = ''
+  end
 
+  def destroy
+    item = Item.find_by(id: @item_id)
+
+    if item
+      invoices = item.invoices.preload(:invoice_items)
+
+      # BEGIN Transaction?
+      # Delete any invoice which only contained the item we just deleted
+      destroy_empty_invoices(invoices)
+
+      # Delete the item (this will also delete invoice_item rows
+      Item.destroy(item_id)
+      # END Transaction?
+    else
+      @error = 'Invalid item id'
+    end
+
+    @error.empty?
+  end
+
+  private
+
+  def destroy_empty_invoices(invoices)
     invoices.each do |invoice|
-      i = invoice.invoice_items
-      require "pry"; binding.pry
-      Invoice.destroy(invoice.id) if invoice.invoice_items.empty?
+      invoice.destroy if invoice.invoice_items.count == 1
     end
   end
 end

--- a/app/services/item_destroyer.rb
+++ b/app/services/item_destroyer.rb
@@ -1,0 +1,17 @@
+class ItemDestroyer
+  def self.destroy_consider_invoice(id)
+    item = Item.find(id)
+    invoices = item.invoices.includes(:invoice_items)
+
+    invoice_ids = item
+    require "pry"; binding.pry
+    destroy(id)
+    require "pry"; binding.pry
+
+    invoices.each do |invoice|
+      i = invoice.invoice_items
+      require "pry"; binding.pry
+      Invoice.destroy(invoice.id) if invoice.invoice_items.empty?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/merchants/find_one', to: 'merchants/search#show'
       resources :merchants, only: [:index, :show]
-      resources :items, only: [:index, :show, :create, :update]
+      resources :items, only: [:index, :show, :create, :update, :destroy]
 
       namespace :revenue do
         get '/merchants/:id', to: 'merchants#show'

--- a/spec/requests/api/v1/items/delete_request_spec.rb
+++ b/spec/requests/api/v1/items/delete_request_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe 'Delete item request' do
+  describe 'happy path' do
+    it 'deletes item when passed a valid id' do
+      merchant = create(:merchant)
+      item = create(:item, merchant: merchant)
+
+      delete api_v1_item_path(item)
+      expect(response).to have_http_status(204)
+
+      expect(Item.exists?(item.id)).to eq(false)
+    end
+
+    it 'deletes related invoice_item rows, preserving invoice if invoice has multiple items' do
+      merchant = create(:merchant)
+      item1 = create(:item, merchant: merchant)
+      item2 = create(:item)
+      invoice = create(:invoice)
+      invoice_item1 = create(:invoice_item, invoice_id: invoice.id, item_id: item1.id)
+      invoice_item2 = create(:invoice_item, invoice_id: invoice.id, item_id: item2.id)
+
+      delete api_v1_item_path(item1)
+      expect(response).to have_http_status(204)
+      expect(Item.exists?(item1.id)).to eq(false)
+      expect(InvoiceItem.exists?(invoice_item1.id)).to eq(false)
+      expect(Invoice.exists?(invoice.id)).to eq(true)
+    end
+
+    it 'deletes invoice if this item was the only on the invoice' do
+      merchant = create(:merchant)
+      item = create(:item, merchant: merchant)
+      invoice = create(:invoice)
+      invoice_item = create(:invoice_item, invoice_id: invoice.id, item_id: item.id)
+
+      delete api_v1_item_path(item)
+      expect(response).to have_http_status(204)
+      expect(Item.exists?(item.id)).to eq(false)
+      expect(InvoiceItem.exists?(invoice_item.id)).to eq(false)
+      expect(Invoice.exists?(invoice.id)).to eq(false)
+    end
+  end
+
+  describe 'sad path' do
+    it 'returns __WHAT?__ when passed invalid id' do
+    end
+  end
+end

--- a/spec/requests/api/v1/items/delete_request_spec.rb
+++ b/spec/requests/api/v1/items/delete_request_spec.rb
@@ -42,7 +42,9 @@ describe 'Delete item request' do
   end
 
   describe 'sad path' do
-    it 'returns __WHAT?__ when passed invalid id' do
+    it 'returns 400 when passed invalid id' do
+      delete api_v1_item_path('foo')
+      expect(response).to have_http_status(400)
     end
   end
 end

--- a/spec/services/item_destroyer_spec.rb
+++ b/spec/services/item_destroyer_spec.rb
@@ -1,13 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe 'Item destroyer' do
+RSpec.describe 'ItemDestroyer' do
   it 'exists' do
-    destroyer = ItemDestroyer.new
+    item = create(:item)
+    destroyer = ItemDestroyer.new(item.id)
+
+    expect(destroyer).to be_an(ItemDestroyer)
+    expect(destroyer.error).to eq('')
   end
 
   describe 'deleting items' do
     it 'deletes items' do
+      item = create(:item)
+      destroyer = ItemDestroyer.new(item.id)
 
+      result = destroyer.destroy
+
+      expect(result).to eq(true)
+      expect(destroyer.error).to eq('')
+      expect(Item.exists?(item.id)).to eq(false)
     end
 
     it 'leaves invoice alone if invoice still has other items' do
@@ -18,8 +29,11 @@ RSpec.describe 'Item destroyer' do
       invoice_item1 = create(:invoice_item, invoice_id: invoice.id, item_id: item1.id)
       invoice_item2 = create(:invoice_item, invoice_id: invoice.id, item_id: item2.id)
 
-      Item.destroy_consider_invoice(item1.id)
+      destroyer = ItemDestroyer.new(item1.id)
+      result = destroyer.destroy
 
+      expect(result).to eq(true)
+      expect(destroyer.error).to eq('')
       expect(Item.exists?(item1.id)).to eq(false)
       expect(InvoiceItem.exists?(invoice_item1.id)).to eq(false)
       expect(Invoice.exists?(invoice.id)).to eq(true)
@@ -31,11 +45,24 @@ RSpec.describe 'Item destroyer' do
       invoice = create(:invoice)
       invoice_item = create(:invoice_item, invoice_id: invoice.id, item_id: item.id)
 
-      Item.destroy_consider_invoice(item.id)
+      destroyer = ItemDestroyer.new(item.id)
+      result = destroyer.destroy
 
+      expect(result).to eq(true)
+      expect(destroyer.error).to eq('')
       expect(Item.exists?(item.id)).to eq(false)
       expect(InvoiceItem.exists?(invoice_item.id)).to eq(false)
       expect(Invoice.exists?(invoice.id)).to eq(false)
+    end
+  end
+
+  describe 'sad path' do
+    it 'returns false and sets error when bad item id is passed in' do
+      destroyer = ItemDestroyer.new('foo')
+      result = destroyer.destroy
+
+      expect(result).to eq(false)
+      expect(destroyer.error).to eq('Invalid item id')
     end
   end
 end

--- a/spec/services/item_destroyer_spec.rb
+++ b/spec/services/item_destroyer_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Item destroyer' do
+  it 'exists' do
+    destroyer = ItemDestroyer.new
+  end
+
+  describe 'deleting items' do
+    it 'deletes items' do
+
+    end
+
+    it 'leaves invoice alone if invoice still has other items' do
+      merchant = create(:merchant)
+      item1 = create(:item, merchant: merchant)
+      item2 = create(:item)
+      invoice = create(:invoice)
+      invoice_item1 = create(:invoice_item, invoice_id: invoice.id, item_id: item1.id)
+      invoice_item2 = create(:invoice_item, invoice_id: invoice.id, item_id: item2.id)
+
+      Item.destroy_consider_invoice(item1.id)
+
+      expect(Item.exists?(item1.id)).to eq(false)
+      expect(InvoiceItem.exists?(invoice_item1.id)).to eq(false)
+      expect(Invoice.exists?(invoice.id)).to eq(true)
+    end
+
+    it 'deletes invoice if deleting item leaves invoice empty' do
+      merchant = create(:merchant)
+      item = create(:item, merchant: merchant)
+      invoice = create(:invoice)
+      invoice_item = create(:invoice_item, invoice_id: invoice.id, item_id: item.id)
+
+      Item.destroy_consider_invoice(item.id)
+
+      expect(Item.exists?(item.id)).to eq(false)
+      expect(InvoiceItem.exists?(invoice_item.id)).to eq(false)
+      expect(Invoice.exists?(invoice.id)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
### What Changed
- Add item delete endpoint, closes #14 
  - Includes addition of a new `ItemDestroyer` class
  - Deletes invoice_items as well as invoices where the deleted item was the only invoice item

### Next Steps
- DO MOAR ENDPOINTS

### Known Issues
- `ItemDestroyer#destroy` should probably be in a transaction so it's all-or-nothing? 
